### PR TITLE
[HOTFIX] Fix factory response

### DIFF
--- a/app/factories/dns_record_factory.rb
+++ b/app/factories/dns_record_factory.rb
@@ -19,7 +19,7 @@ class DnsRecordFactory
       Success(associate(dns_record, hosts))
     end
   rescue ActiveRecord::RecordNotUnique
-    Failure("DnsRecord already present")
+    Failure(OpenStruct.new(errors: { ip: ["DnsRecord already present"] }))
   end
 
   private

--- a/spec/controllers/dns_records_controller_spec.rb
+++ b/spec/controllers/dns_records_controller_spec.rb
@@ -50,5 +50,26 @@ RSpec.describe DnsRecordsController, type: :controller do
         )
       end
     end
+
+    context "with duplicated ip record" do
+      it "returns the error information" do
+        DnsRecord.create!(ip: "1.1.1.1")
+
+        post :create, params: {
+          dns_records: {
+            ip: "1.1.1.1",
+            hostname_attributes: [
+              "a.com",
+              "b.com"
+            ]
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON(response.body)).to eq(
+          "errors" => { "ip" => ["DnsRecord already present"] }
+        )
+      end
+    end
   end
 end

--- a/spec/factories/dns_record_factory_spec.rb
+++ b/spec/factories/dns_record_factory_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe DnsRecordFactory do
         result = factory.call(ip: "1.1.1.1", hostname_attributes: %w[a.com b.com])
 
         expect(result).to be_failure
-        expect(result.failure).to eq("DnsRecord already present")
+        expect(result.failure.errors.to_h).to eq(ip: ["DnsRecord already present"])
       end
     end
   end


### PR DESCRIPTION
The factory response for duplicated records is returning a Failure with
a string and this return isn't compatible with Dry::Schema interface to
represent failures.